### PR TITLE
Fix trashed post ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 nbproject
 thumb.db
 Thumbs.db
+.idea/*
 
 
 # Project specific files to ignore

--- a/cmb-field-select2.php
+++ b/cmb-field-select2.php
@@ -2,6 +2,7 @@
 /*
 Plugin Name: CMB Field Type: Select2
 Plugin URI: https://github.com/mustardBees/cmb-field-select2
+GitHub Plugin URI: https://github.com/mustardBees/cmb-field-select2
 Description: Select2 field type for Custom Metaboxes and Fields for WordPress
 Version: 2.0.4
 Author: Phil Wylie

--- a/js/select2-init.js
+++ b/js/select2-init.js
@@ -25,6 +25,12 @@
 							id: this,
 							text: text
 						});
+					} else {
+						// If the post title isn't found in the post data, the post has been
+						// trashed or deleted, and should be removed from the metadata
+						var val = element.val().split( ',' );
+						val.splice( val.indexOf( this.valueOf() ), 1 );
+						element.val( val );
 					}
 				});
 


### PR DESCRIPTION
This includes a fix to remove post IDs that are present in the stored value but are missing in the data supplied to the UI. Needs: a bump in major version number and a clear message in the release notes should suffice.

Also included are two minor changes to gitignore JetBrains IDE files, and to respect the GitHub Updater plugin.