### PR TITLE
Add a type "wordpress-plugin" to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "mustardBees/cmb-field-select2",
+    "type": "wordpress-plugin",
     "description": "Select2 field type for Custom Metaboxes and Fields for WordPress",
     "homepage": "https://github.com/mustardBees/cmb-field-select2"
 }


### PR DESCRIPTION
This will make composer install easier allowing to automatically install the plugin in the right place in Wordpress arborescence.