### PR TITLE
Versions > 2.2.2 require initiation of a type object

### DIFF
--- a/cmb-field-select2.php
+++ b/cmb-field-select2.php
@@ -37,6 +37,10 @@ class PW_CMB2_Field_Select2 {
 	public function render_pw_select( $field, $field_escaped_value, $field_object_id, $field_object_type, $field_type_object ) {
 		$this->setup_admin_scripts();
 
+		if ( version_compare( CMB2_VERSION, '2.2.2', '>=' ) ) {
+			$field_type_object->type = new CMB2_Type_Select( $field_type_object );
+		}
+
 		echo $field_type_object->select( array(
 			'class'            => 'pw_select2 pw_select',
 			'desc'             => $field_type_object->_desc( true ),


### PR DESCRIPTION
The type object is needs to be initiated and added to the types object in order for some of the methods to work (like `concat_items`). This ensures it will work in the future while also still working for older versions of CMB2.