### PR TITLE
Fix parameter follows optional parameter cmb-field-select2.php:83

### DIFF
--- a/cmb-field-select2.php
+++ b/cmb-field-select2.php
@@ -4,7 +4,7 @@ Plugin Name: CMB2 Field Type: Select2
 Plugin URI: https://github.com/mustardBees/cmb-field-select2
 GitHub Plugin URI: https://github.com/mustardBees/cmb-field-select2
 Description: Select2 field type for CMB2.
-Version: 3.0.3
+Version: 3.0.4-dev
 Author: Phil Wylie
 Author URI: https://www.philwylie.co.uk/
 License: GPLv2+
@@ -75,12 +75,14 @@ class PW_CMB2_Field_Select2 {
 	}
 
 	/**
-	 * Return list of options for pw_multiselect
+	 * Return list of options for pw_multiselect.
+	 * 
+	 * @version 3.0.4
 	 *
 	 * Return the list of options, with selected options at the top preserving their order. This also handles the
 	 * removal of selected options which no longer exist in the options array.
 	 */
-	public function get_pw_multiselect_options( $field_escaped_value = array(), $field_type_object ) {
+	public function get_pw_multiselect_options( $field_escaped_value = array(), $field_type_object = null ) {
 		$options = (array) $field_type_object->field->options();
 
 		// If we have selected items, we need to preserve their order


### PR DESCRIPTION
Fixes this warning from PHP 8.0:

PHP Deprecated:  Required parameter $field_type_object follows optional parameter $field_escaped_value in mustardBees\cmb-field-select2\cmb-field-select2.php on line 83